### PR TITLE
Add DELETE operation for resource targets

### DIFF
--- a/draft-wwlh-netconf-list-pagination-rc.xml
+++ b/draft-wwlh-netconf-list-pagination-rc.xml
@@ -84,7 +84,7 @@
         <relref section="4.8" target="RFC8040"/> to enable pagination over
         optionally filtered and/or sorted "list" and "leaf-list" entries.</t>
       <t>This document Updates RFC 8040 to declare "list" and "leaf-list" as
-        valid resource targets for the RESTCONF GET operation.</t>
+        valid resource targets for the RESTCONF GET and DELETE operations.</t>
       <t>The RPC operation defined in <xref target="I-D.wwlh-netconf-list-pagination-nc"/>
         may be optionally used if the RESTCONF server implements the
         "ietf-netconf-list-pagination" module.</t>


### PR DESCRIPTION
Add DELETE operation as valid operation on resource targets,
e.g. lists and leaf-lists.

This is a common use case, not wanting to delete the entire
list by iterating over the contents but instead targeting the
list itself.